### PR TITLE
Fix stereodemo dataset path and mutable default in dataclass

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,4 @@
 [metadata]
-# replace with your username:
 name = stereodemo
 version = 0.6
 author = Nicolas Burrus
@@ -36,6 +35,6 @@ console_scripts =
     stereodemo = stereodemo:main
 
 [options.package_data]
-    # This relies on a symlink to datasets existing under stereodemo/
-    # This is done by build_release.sh
-    stereodemo = datasets/oak-d/*.png, datasets/oak-d/*.json
+# This relies on a symlink to datasets existing under stereodemo/
+# This is done by build_release.sh
+stereodemo = datasets/oak-d/*.png, datasets/oak-d/*.json

--- a/stereodemo/methods.py
+++ b/stereodemo/methods.py
@@ -1,14 +1,11 @@
-
-
 from abc import abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
-
 from typing import Any, Dict, List, Tuple
 import time
 import json
-
 import numpy as np
+
 
 @dataclass
 class Calibration:
@@ -16,17 +13,19 @@ class Calibration:
     height: int
     fx: float
     fy: float
-    cx0: float # cx is the only one that can differ between both cameras.
+    cx0: float  # cx is the only one that can differ between both cameras.
     cx1: float
     cy: float
     baseline_meters: float
     depth_range: Tuple[float] = (0.3, 20.0)
-    left_image_rect_normalized: np.ndarray = np.array([0.,0.,1.,1.]) # origin, size in percent of image size
+    left_image_rect_normalized: np.ndarray = field(
+        default_factory=lambda: np.array([0., 0., 1., 1.])) # origin, size in percent of image size
     comment: str = ""
 
     def to_json(self):
         return json.dumps(self.__dict__)
 
+    @staticmethod
     def from_json(json_str):
         d = json.loads(json_str)
         return Calibration(**d)
@@ -42,6 +41,7 @@ class Calibration:
         self.cx1 *= sx
         self.cy *= sy
 
+
 @dataclass
 class InputPair:
     left_image: np.ndarray
@@ -53,6 +53,7 @@ class InputPair:
     def has_data(self):
         return self.left_image is not None
 
+
 @dataclass
 class StereoOutput:
     disparity_pixels: np.ndarray
@@ -61,36 +62,40 @@ class StereoOutput:
     point_cloud: Any = None
     disparity_color: np.ndarray = None
 
+
 @dataclass
 class IntParameter:
     description: str
     value: int
     min: int
     max: int
-    to_valid: Any = lambda x: x # default is to just accept anything
+    to_valid: Any = lambda x: x  # default is to just accept anything
 
-    def set_value (self, x: int):
+    def set_value(self, x: int):
         self.value = self.to_valid(x)
+
 
 @dataclass
 class EnumParameter:
     description: str
-    index: int # index in the list
+    index: int  # index in the list
     values: List[str]
 
-    def set_index (self, idx: int):
+    def set_index(self, idx: int):
         self.index = idx
 
-    def set_value (self, value):
+    def set_value(self, value):
         self.index = self.values.index(value)
 
     @property
     def value(self) -> str:
         return self.values[self.index]
 
+
 @dataclass
 class Config:
     models_path: Path
+
 
 class StereoMethod:
     def __init__(self, name: str, description: str, parameters: Dict, config: Config):
@@ -102,14 +107,15 @@ class StereoMethod:
     def reset_defaults(self):
         pass
 
-    @abstractmethod    
+    @abstractmethod
     def compute_disparity(self, input: InputPair) -> StereoOutput:
         """Return the disparity map in pixels and the actual computation time.
-        
+
         Both input images are assumed to be rectified.
         """
         return StereoOutput(None, None, None, None)
 
+    @staticmethod
     def depth_meters_from_disparity(disparity_pixels: np.ndarray, calibration: Calibration):
         old_seterr = np.seterr(divide='ignore')
         dcx = np.float32(calibration.cx0 - calibration.cx1)
@@ -119,6 +125,7 @@ class StereoMethod:
         np.seterr(**old_seterr)
         return depth_meters
 
+    @staticmethod
     def disparity_from_depth_meters(depth_meters: np.ndarray, calibration: Calibration):
         old_seterr = np.seterr(divide='ignore')
         dcx = np.float32(calibration.cx0 - calibration.cx1)


### PR DESCRIPTION
This PR addresses two key issues in the `stereodemo` project:  

1. **Fixed dataset path handling in `setup.cfg`**  
2. **Fixed `ValueError` caused by mutable default in a dataclass**  
   - Replaced `left_image_rect_normalized: np.ndarray = np.array([0., 0., 1., 1.])`  
   - Used `field(default_factory=lambda: np.array([0., 0., 1., 1.]))` to comply with Python’s `dataclass` behavior.  

### **Additional Fixes & Improvements:**  
- Resolved `pytest` failure caused by an **unexpected value continuation** in `setup.cfg`.  
- Verified proper execution of `stereodemo` without import errors.  

### **Testing & Validation:**  
- Ran `pytest` to confirm tests execute correctly.  
- Validated correct behavior when launching `stereodemo`.  

This PR ensures compatibility with newer python versions while maintaining expected functionality.  

Let me know if additional changes or testing is required