### PR TITLE
OpenCV CUDA methods implementation

### DIFF
--- a/stereodemo/main.py
+++ b/stereodemo/main.py
@@ -16,6 +16,8 @@ from . import visualizer
 from . import methods
 
 from .method_opencv_bm import StereoBM, StereoSGBM
+from .method_opencv_cuda_bp import StereoCudaBP
+from .method_opencv_cuda_csbp import StereoCudaCSBP
 from .method_raft_stereo import RaftStereo
 from .method_cre_stereo import CREStereo
 from .method_chang_realtime_stereo import ChangRealtimeStereo
@@ -161,6 +163,8 @@ def main():
     method_list = [
         StereoBM(config),
         StereoSGBM(config),
+        StereoCudaBP(config),
+        StereoCudaCSBP(config),
         CREStereo(config),
         RaftStereo(config),
         HitnetStereo(config),

--- a/stereodemo/method_opencv_cuda_bp.py
+++ b/stereodemo/method_opencv_cuda_bp.py
@@ -1,0 +1,52 @@
+import time
+
+import numpy as np
+import cv2
+
+from .methods import Config, StereoMethod, IntParameter, EnumParameter, InputPair, StereoOutput
+
+
+class StereoCudaBP(StereoMethod):
+    def __init__(self, config: Config):
+        super().__init__("OpenCV CUDA BP", "OpenCV CUDA Stereo Belief Propagation", {}, config)
+        self.reset_defaults()
+
+    def reset_defaults(self):
+        self.parameters.update({
+            "Num Disparities": IntParameter("Number of disparities (pixels)", 64, 16, 256),
+            "Num Iterations": IntParameter("Number of BP iterations on each pyramid level", 5, 1, 50),
+            "Num Levels": IntParameter("Number of pyramid levels", 5, 1, 10),
+            "Max Data Term x10": IntParameter("Truncation of data cost (divide by 10 for actual value)", 100, 1, 2000),
+            "Data Weight x1000": IntParameter("Weight of data cost (divide by 1000 for actual value)", 70, 1, 1000),
+            "Max Disc Term x10": IntParameter("Truncation of discontinuity cost (divide by 10 for actual value)", 17, 1, 200),
+            "Disc Single Jump x10": IntParameter("Discontinuity single jump (divide by 10 for actual value)", 10, 1, 200),
+            "Msg Type": EnumParameter("Message type for internal computation buffers", 0, ["CV_32F", "CV_16S"]),
+        })
+
+    def compute_disparity(self, input: InputPair) -> StereoOutput:
+        if cv2.cuda.getCudaEnabledDeviceCount() == 0:
+            raise RuntimeError("No CUDA-enabled GPU detected. OpenCV CUDA BP requires a CUDA-capable device.")
+
+        msg_type = cv2.CV_32F if self.parameters['Msg Type'].index == 0 else cv2.CV_16S
+        stereo = cv2.cuda.createStereoBeliefPropagation(
+            ndisp=self.parameters['Num Disparities'].value,
+            iters=self.parameters['Num Iterations'].value,
+            levels=self.parameters['Num Levels'].value,
+            msg_type=msg_type,
+        )
+        stereo.setMaxDataTerm(self.parameters['Max Data Term x10'].value / 10.0)
+        stereo.setDataWeight(self.parameters['Data Weight x1000'].value / 1000.0)
+        stereo.setMaxDiscTerm(self.parameters['Max Disc Term x10'].value / 10.0)
+        stereo.setDiscSingleJump(self.parameters['Disc Single Jump x10'].value / 10.0)
+
+        gpu_left = cv2.cuda_GpuMat()
+        gpu_right = cv2.cuda_GpuMat()
+        gpu_left.upload(input.left_image)
+        gpu_right.upload(input.right_image)
+
+        start = time.time()
+        gpu_disparity = stereo.compute(gpu_left, gpu_right)
+        disparity = gpu_disparity.download().astype(np.float32)
+        elapsed = time.time() - start
+
+        return StereoOutput(disparity, input.left_image, elapsed)

--- a/stereodemo/method_opencv_cuda_bp.py
+++ b/stereodemo/method_opencv_cuda_bp.py
@@ -25,16 +25,22 @@ class StereoCudaBP(StereoMethod):
 
     def compute_disparity(self, input: InputPair) -> StereoOutput:
         if cv2.cuda.getCudaEnabledDeviceCount() == 0:
-            raise RuntimeError("No CUDA-enabled GPU detected. OpenCV CUDA BP requires a CUDA-capable device.")
+            raise RuntimeError("CUDA-capable device not available or OpenCV not compiled with CUDA support.")
 
         msg_type = cv2.CV_32F if self.parameters['Msg Type'].index == 0 else cv2.CV_16S
+        h, w = input.left_image.shape[:2]
+        max_levels = max(1, (min(h, w) // 3).bit_length())
+        levels = min(self.parameters['Num Levels'].value, max_levels)
         stereo = cv2.cuda.createStereoBeliefPropagation(
             ndisp=self.parameters['Num Disparities'].value,
             iters=self.parameters['Num Iterations'].value,
-            levels=self.parameters['Num Levels'].value,
+            levels=levels,
             msg_type=msg_type,
         )
-        stereo.setMaxDataTerm(self.parameters['Max Data Term x10'].value / 10.0)
+        max_data_term = self.parameters['Max Data Term x10'].value / 10.0
+        if msg_type == cv2.CV_16S:
+            max_data_term = min(max_data_term, (np.iinfo(np.int16).max - 1) / (10.0 * (1 << (levels - 1))))
+        stereo.setMaxDataTerm(max_data_term)
         stereo.setDataWeight(self.parameters['Data Weight x1000'].value / 1000.0)
         stereo.setMaxDiscTerm(self.parameters['Max Disc Term x10'].value / 10.0)
         stereo.setDiscSingleJump(self.parameters['Disc Single Jump x10'].value / 10.0)
@@ -44,9 +50,11 @@ class StereoCudaBP(StereoMethod):
         gpu_left.upload(input.left_image)
         gpu_right.upload(input.right_image)
 
+        stream = cv2.cuda.Stream()
         start = time.time()
-        gpu_disparity = stereo.compute(gpu_left, gpu_right)
-        disparity = gpu_disparity.download().astype(np.float32)
+        gpu_disparity = stereo.compute(gpu_left, gpu_right, stream)
+        stream.waitForCompletion()
         elapsed = time.time() - start
+        disparity = gpu_disparity.download().astype(np.float32)
 
         return StereoOutput(disparity, input.left_image, elapsed)

--- a/stereodemo/method_opencv_cuda_csbp.py
+++ b/stereodemo/method_opencv_cuda_csbp.py
@@ -21,36 +21,44 @@ class StereoCudaCSBP(StereoMethod):
             "Data Weight x1000": IntParameter("Weight of data cost (divide by 1000 for actual value)", 70, 1, 1000),
             "Max Disc Term x10": IntParameter("Truncation of discontinuity cost (divide by 10 for actual value)", 17, 1, 200),
             "Disc Single Jump x10": IntParameter("Discontinuity single jump (divide by 10 for actual value)", 10, 1, 200),
-            "Min Disp Threshold": IntParameter("Minimum disparity threshold for the level selection strategy", 0, 0, 100),
+            "Min Disparity": IntParameter("Minimum possible disparity value", 0, 0, 100),
             "Msg Type": EnumParameter("Message type for internal computation buffers", 0, ["CV_32F", "CV_16S"]),
         })
 
     def compute_disparity(self, input: InputPair) -> StereoOutput:
         if cv2.cuda.getCudaEnabledDeviceCount() == 0:
-            raise RuntimeError("No CUDA-enabled GPU detected. OpenCV CUDA CSBP requires a CUDA-capable device.")
+            raise RuntimeError("CUDA-capable device not available or OpenCV not compiled with CUDA support.")
 
         msg_type = cv2.CV_32F if self.parameters['Msg Type'].index == 0 else cv2.CV_16S
+        h, w = input.left_image.shape[:2]
+        max_levels = max(1, (min(h, w) // 3).bit_length())
+        levels = min(self.parameters['Num Levels'].value, max_levels)
         stereo = cv2.cuda.createStereoConstantSpaceBP(
             ndisp=self.parameters['Num Disparities'].value,
             iters=self.parameters['Num Iterations'].value,
-            levels=self.parameters['Num Levels'].value,
+            levels=levels,
             nr_plane=self.parameters['Nr Plane'].value,
             msg_type=msg_type,
         )
-        stereo.setMaxDataTerm(self.parameters['Max Data Term x10'].value / 10.0)
+        max_data_term = self.parameters['Max Data Term x10'].value / 10.0
+        if msg_type == cv2.CV_16S:
+            max_data_term = min(max_data_term, (np.iinfo(np.int16).max - 1) / (10.0 * (1 << (levels - 1))))
+        stereo.setMaxDataTerm(max_data_term)
         stereo.setDataWeight(self.parameters['Data Weight x1000'].value / 1000.0)
         stereo.setMaxDiscTerm(self.parameters['Max Disc Term x10'].value / 10.0)
         stereo.setDiscSingleJump(self.parameters['Disc Single Jump x10'].value / 10.0)
-        stereo.setMinDispTh(self.parameters['Min Disp Threshold'].value)
+        stereo.setMinDisparity(self.parameters['Min Disparity'].value)
 
         gpu_left = cv2.cuda_GpuMat()
         gpu_right = cv2.cuda_GpuMat()
         gpu_left.upload(input.left_image)
         gpu_right.upload(input.right_image)
 
+        stream = cv2.cuda.Stream()
         start = time.time()
-        gpu_disparity = stereo.compute(gpu_left, gpu_right)
-        disparity = gpu_disparity.download().astype(np.float32)
+        gpu_disparity = stereo.compute(gpu_left, gpu_right, stream)
+        stream.waitForCompletion()
         elapsed = time.time() - start
+        disparity = gpu_disparity.download().astype(np.float32)
 
         return StereoOutput(disparity, input.left_image, elapsed)

--- a/stereodemo/method_opencv_cuda_csbp.py
+++ b/stereodemo/method_opencv_cuda_csbp.py
@@ -1,0 +1,56 @@
+import time
+
+import numpy as np
+import cv2
+
+from .methods import Config, StereoMethod, IntParameter, EnumParameter, InputPair, StereoOutput
+
+
+class StereoCudaCSBP(StereoMethod):
+    def __init__(self, config: Config):
+        super().__init__("OpenCV CUDA CSBP", "OpenCV CUDA Constant Space Belief Propagation", {}, config)
+        self.reset_defaults()
+
+    def reset_defaults(self):
+        self.parameters.update({
+            "Num Disparities": IntParameter("Number of disparities (pixels)", 128, 16, 256),
+            "Num Iterations": IntParameter("Number of BP iterations on each pyramid level", 8, 1, 50),
+            "Num Levels": IntParameter("Number of pyramid levels", 4, 1, 10),
+            "Nr Plane": IntParameter("Number of active disparity levels on each pyramid level", 4, 1, 64),
+            "Max Data Term x10": IntParameter("Truncation of data cost (divide by 10 for actual value)", 100, 1, 2000),
+            "Data Weight x1000": IntParameter("Weight of data cost (divide by 1000 for actual value)", 70, 1, 1000),
+            "Max Disc Term x10": IntParameter("Truncation of discontinuity cost (divide by 10 for actual value)", 17, 1, 200),
+            "Disc Single Jump x10": IntParameter("Discontinuity single jump (divide by 10 for actual value)", 10, 1, 200),
+            "Min Disp Threshold": IntParameter("Minimum disparity threshold for the level selection strategy", 0, 0, 100),
+            "Msg Type": EnumParameter("Message type for internal computation buffers", 0, ["CV_32F", "CV_16S"]),
+        })
+
+    def compute_disparity(self, input: InputPair) -> StereoOutput:
+        if cv2.cuda.getCudaEnabledDeviceCount() == 0:
+            raise RuntimeError("No CUDA-enabled GPU detected. OpenCV CUDA CSBP requires a CUDA-capable device.")
+
+        msg_type = cv2.CV_32F if self.parameters['Msg Type'].index == 0 else cv2.CV_16S
+        stereo = cv2.cuda.createStereoConstantSpaceBP(
+            ndisp=self.parameters['Num Disparities'].value,
+            iters=self.parameters['Num Iterations'].value,
+            levels=self.parameters['Num Levels'].value,
+            nr_plane=self.parameters['Nr Plane'].value,
+            msg_type=msg_type,
+        )
+        stereo.setMaxDataTerm(self.parameters['Max Data Term x10'].value / 10.0)
+        stereo.setDataWeight(self.parameters['Data Weight x1000'].value / 1000.0)
+        stereo.setMaxDiscTerm(self.parameters['Max Disc Term x10'].value / 10.0)
+        stereo.setDiscSingleJump(self.parameters['Disc Single Jump x10'].value / 10.0)
+        stereo.setMinDispTh(self.parameters['Min Disp Threshold'].value)
+
+        gpu_left = cv2.cuda_GpuMat()
+        gpu_right = cv2.cuda_GpuMat()
+        gpu_left.upload(input.left_image)
+        gpu_right.upload(input.right_image)
+
+        start = time.time()
+        gpu_disparity = stereo.compute(gpu_left, gpu_right)
+        disparity = gpu_disparity.download().astype(np.float32)
+        elapsed = time.time() - start
+
+        return StereoOutput(disparity, input.left_image, elapsed)

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -14,6 +14,8 @@ from stereodemo import method_hitnet
 from stereodemo import method_cre_stereo
 from stereodemo import method_raft_stereo
 from stereodemo import method_sttr
+from stereodemo import method_opencv_cuda_bp
+from stereodemo import method_opencv_cuda_csbp
 from stereodemo.methods import Config, InputPair, Calibration, StereoOutput, StereoMethod
 
 data_folder = Path(__file__).parent.parent / 'datasets' / 'eth3d_lowres' / 'delivery_area_1l'
@@ -27,6 +29,10 @@ models_path.mkdir(parents=True, exist_ok=True)
 config = Config(models_path)
 
 class TestStereoInference(unittest.TestCase):
+
+    @staticmethod
+    def _opencv_cuda_available() -> bool:
+        return hasattr(cv2, "cuda") and cv2.cuda.getCudaEnabledDeviceCount() > 0
 
     def check_method(self, method: StereoMethod, expected_median: float, expected_coverage: float):
         output = method.compute_disparity (input)
@@ -66,6 +72,16 @@ class TestStereoInference(unittest.TestCase):
         m = method_sttr.StereoTransformers(config)
         m.parameters["Shape"].set_value ("640x480 (ds3)")
         self.check_method (m, 7.4636, 0.9869)
+
+    def test_cuda_bp(self):
+        if not self._opencv_cuda_available():
+            self.skipTest("OpenCV CUDA is not available")
+        self.check_method (method_opencv_cuda_bp.StereoCudaBP(config), 5.0, 0.9)
+
+    def test_cuda_csbp(self):
+        if not self._opencv_cuda_available():
+            self.skipTest("OpenCV CUDA is not available")
+        self.check_method (method_opencv_cuda_csbp.StereoCudaCSBP(config), 6.0, 0.9)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Implementation of [cv::cuda::StereoBeliefPropagation](https://docs.opencv.org/4.x/de/d7a/classcv_1_1cuda_1_1StereoBeliefPropagation.html) and [cv::cuda::StereoConstantSpaceBP](https://docs.opencv.org/4.x/d7/d09/classcv_1_1cuda_1_1StereoConstantSpaceBP.html) methods.
OpenCV source needs to be downloaded, compiled and installed with CUDA support.
Compiled Python package with CUDA bindings needs to be pip-installed (as pypi opencv-python is CPU-only).

P.D.: Such a great tool, we use it in a computer vision class to showcase disparity methods.