### PR TITLE
fix: replace bare except clauses with specific exception types

### DIFF
--- a/stereodemo/main.py
+++ b/stereodemo/main.py
@@ -84,7 +84,7 @@ class FileListSource (visualizer.Source):
                     continue
                 try:
                     right_f = file_or_dir_list.pop(0)
-                except:
+                except IndexError:
                     print (f"Missing right image for {f}, skipping")
                     continue
                 self.left_images_path.append(f)
@@ -157,8 +157,8 @@ def main():
         sys.stderr.write (f"Going to use the temporary directory {args.models_path} instead, specify --model-paths to specify a custom persistent path instead.\n")
         try:
             args.models_path.mkdir(parents=True, exist_ok=True)
-        except:
-            sys.stderr.write ("Could not create a temporary directory to store the downloaded models.\n")
+        except OSError as e:
+            sys.stderr.write (f"Could not create a temporary directory to store the downloaded models: {e}\n")
             sys.stderr.write ("Aborting, you need to specify --models-path with a valid writable path.\n")
             sys.exit (1)
     print (f"INFO: will store downloaded models in {args.models_path}")


### PR DESCRIPTION
Replaced two bare `except:` clauses in `stereodemo/main.py` with specific exception types and added the underlying error to the diagnostic message.

**Why:**
- Bare `except:` catches `SystemExit` and `KeyboardInterrupt`, which can hide user-initiated exits and make Ctrl+C unreliable.
- `file_or_dir_list.pop(0)` raises `IndexError` on an empty list — that's the only realistic failure mode, so the catch should reflect it.
- `Path.mkdir` raises `OSError` subclasses (`PermissionError`, `FileNotFoundError`, etc.) when it fails. Including `{e}` in the stderr message tells the user *why* the path is not writable instead of a generic warning.

**Diff:**
```diff
                 try:
                     right_f = file_or_dir_list.pop(0)
-                except:
+                except IndexError:
                     print (f"Missing right image for {f}, skipping")
                     continue
 ...
         try:
             args.models_path.mkdir(parents=True, exist_ok=True)
-        except:
-            sys.stderr.write ("Could not create a temporary directory to store the downloaded models.\n")
+        except OSError as e:
+            sys.stderr.write (f"Could not create a temporary directory to store the downloaded models: {e}\n")
             sys.stderr.write ("Aborting, you need to specify --models-path with a valid writable path.\n")
             sys.exit (1)
```

No behavior change for legitimate failure paths — just clearer exceptions and a useful error message.

— Sent via @AmSach bot